### PR TITLE
Update index templates to be compatible with the latest version(8.0)

### DIFF
--- a/Elasticsearch/Index Template/index_template_curl_auth.txt
+++ b/Elasticsearch/Index Template/index_template_curl_auth.txt
@@ -1,79 +1,79 @@
-curl --location --request GET 'localhost:9200/_template/auth?include_type_name' \
+curl --location --request PUT 'localhost:9200/_index_template/auth' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-  "version": 60001,
-  "order": 0,
-  "index_patterns": [
-    "auth*"
-  ],
-  "settings": {
-    "index": {
-      "lifecycle": {
-        "name": "logstash-policy",
-        "rollover_alias": "logstash"
-      },
-      "number_of_shards": "1",
-      "refresh_interval": "5s"
-    }
-  },
-  "mappings": {
-    "_doc": {
-      "_source": {},
-      "_meta": {},
-      "dynamic_templates": [
-        {
-          "message_field": {
-            "path_match": "message",
-            "mapping": {
-              "norms": false,
-              "type": "text"
+    "version": 60001,
+    "priority": 1,
+    "index_patterns": [
+        "auth-*"
+    ],
+    "template":{
+        "settings":{
+            "index":{
+            "lifecycle":{
+                "name":"logstash-policy",
+                "rollover_alias":"logstash"
             },
-            "match_mapping_type": "string"
-          }
-        },
-        {
-          "string_fields": {
-            "mapping": {
-              "norms": false,
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "ignore_above": 256,
-                  "type": "keyword"
-                }
-              }
-            },
-            "match_mapping_type": "string",
-            "match": "*"
-          }
-        }
-      ],
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
-        "@version": {
-          "type": "keyword"
-        },
-        "geoip": {
-          "dynamic": true,
-          "type": "object",
-          "properties": {
-            "ip": {
-              "type": "ip"
-            },
-            "latitude": {
-              "type": "half_float"
-            },
-            "location": {
-              "type": "geo_point"
-            },
-            "longitude": {
-              "type": "half_float"
+            "number_of_shards":"1",
+            "refresh_interval":"5s"
             }
-          }
+        },
+        "mappings":{
+            "_source":{},
+            "_meta":{},
+            "dynamic_templates":[
+            {
+                "message_field":{
+                    "path_match":"message",
+                    "mapping":{
+                        "norms":false,
+                        "type":"text"
+                    },
+                    "match_mapping_type":"string"
+                }
+            },
+            {
+                "string_fields":{
+                    "mapping":{
+                        "norms":false,
+                        "type":"text",
+                        "fields":{
+                        "keyword":{
+                            "ignore_above":256,
+                            "type":"keyword"
+                        }
+                        }
+                    },
+                    "match_mapping_type":"string",
+                    "match":"*"
+                }
+            }
+            ],
+            "properties":{
+                "@timestamp":{
+                    "type":"date"
+                },
+                "@version":{
+                    "type":"keyword"
+                },
+                "geoip":{
+                    "dynamic":true,
+                    "type":"object",
+                    "properties":{
+                        "ip":{
+                            "type":"ip"
+                        },
+                        "latitude":{
+                            "type":"half_float"
+                        },
+                        "location":{
+                            "type":"geo_point"
+                        },
+                        "longitude":{
+                            "type":"half_float"
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }'

--- a/Elasticsearch/Index Template/index_template_curl_session.txt
+++ b/Elasticsearch/Index Template/index_template_curl_session.txt
@@ -1,99 +1,99 @@
-curl --location --request GET 'localhost:9200/_template/session?include_type_name' \
+curl --location --request PUT 'localhost:9200/_index_template/session' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-  "version": 60001,
-  "order": 0,
-  "index_patterns": [
-    "session*"
-  ],
-  "settings": {
-    "index": {
-      "lifecycle": {
-        "name": "logstash-policy",
-        "rollover_alias": "logstash"
-      },
-      "number_of_shards": "1",
-      "refresh_interval": "5s"
-    }
-  },
-  "mappings": {
-    "_doc": {
-      "dynamic": true,
-      "numeric_detection": false,
-      "date_detection": true,
-      "dynamic_date_formats": [
-        "strict_date_optional_time",
-        "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
-      ],
-      "_source": {
-        "enabled": true,
-        "includes": [],
-        "excludes": []
-      },
-      "_meta": {},
-      "_routing": {
-        "required": false
-      },
-      "dynamic_templates": [
-        {
-          "message_field": {
-            "path_match": "message",
-            "mapping": {
-              "norms": false,
-              "type": "text"
+    "version":60001,
+    "priority":1,
+    "index_patterns":[
+        "session-*"
+    ],
+    "template":{
+        "settings":{
+            "index":{
+            "lifecycle":{
+                "name":"logstash-policy",
+                "rollover_alias":"logstash"
             },
-            "match_mapping_type": "string"
-          }
+            "number_of_shards":"1",
+            "refresh_interval":"5s"
+            }
         },
-        {
-          "string_fields": {
-            "mapping": {
-              "norms": false,
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "ignore_above": 256,
-                  "type": "keyword"
+        "mappings":{
+            "dynamic":true,
+            "numeric_detection":false,
+            "date_detection":true,
+            "dynamic_date_formats":[
+                "strict_date_optional_time",
+                "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
+            ],
+            "_source":{
+                "enabled":true,
+                "includes":[],
+                "excludes":[]
+            },
+            "_meta":{},
+            "_routing":{
+                "required":false
+            },
+            "dynamic_templates":[
+            {
+                "message_field":{
+                    "path_match":"message",
+                    "mapping":{
+                        "norms":false,
+                        "type":"text"
+                    },
+                    "match_mapping_type":"string"
                 }
-              }
             },
-            "match_mapping_type": "string",
-            "match": "*"
-          }
+            {
+                "string_fields":{
+                    "mapping":{
+                        "norms":false,
+                        "type":"text",
+                        "fields":{
+                            "keyword":{
+                                "ignore_above":256,
+                                "type":"keyword"
+                            }
+                        }
+                    },
+                    "match_mapping_type":"string",
+                    "match":"*"
+                }
+            }
+            ],
+            "properties":{
+                "@timestamp":{
+                    "type":"date"
+                },
+                "@version":{
+                    "type":"keyword"
+                },
+                "event.payloadData.renewTimestamp":{
+                    "format":"epoch_millis",
+                    "index":true,
+                    "ignore_malformed":false,
+                    "store":false,
+                    "type":"date",
+                    "doc_values":true
+                },
+                "event.payloadData.startTimestamp":{
+                    "format":"epoch_millis",
+                    "index":true,
+                    "ignore_malformed":false,
+                    "store":false,
+                    "type":"date",
+                    "doc_values":true
+                },
+                "event.payloadData.terminationTimestamp":{
+                    "format":"epoch_millis",
+                    "index":true,
+                    "ignore_malformed":false,
+                    "store":false,
+                    "type":"date",
+                    "doc_values":true
+                }
+            }
         }
-      ],
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
-        "@version": {
-          "type": "keyword"
-        },
-        "event.payloadData.renewTimestamp": {
-          "format": "epoch_millis",
-          "index": true,
-          "ignore_malformed": false,
-          "store": false,
-          "type": "date",
-          "doc_values": true
-        },
-        "event.payloadData.startTimestamp": {
-          "format": "epoch_millis",
-          "index": true,
-          "ignore_malformed": false,
-          "store": false,
-          "type": "date",
-          "doc_values": true
-        },
-        "event.payloadData.terminationTimestamp": {
-          "format": "epoch_millis",
-          "index": true,
-          "ignore_malformed": false,
-          "store": false,
-          "type": "date",
-          "doc_values": true
-        }
-      }
     }
-  }
 }'

--- a/WSO2-IS-Configs/EventPublishers/HTTP/IsAnalytics-Publisher-wso2event-SessionData.xml
+++ b/WSO2-IS-Configs/EventPublishers/HTTP/IsAnalytics-Publisher-wso2event-SessionData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <eventPublisher name="IsAnalytics-Publisher-wso2event-SessionData" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
-  <from streamName="org.wso2.is.analytics.stream.OverallSession" version="1.0.0"/>
+  <from streamName="org.wso2.is.analytics.stream.OverallSession" version="1.0.1"/>
   <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="http">
     <property name="publishingMode">non-blocking</property>


### PR DESCRIPTION
Existing index tempates are written according to the elastic version 7.7. The latest version of elastic is 8.0 and there have been some REST API changes related to the index templates from version 7.7 to 8.0. In this PR, updated the index templates to be compatible with the latest version. 

See the Index template REST API changes;
7.7 - [https://www.elastic.co/guide/en/elasticsearch/reference/7.7/indices-templates.html](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/indices-templates.html)

8.0 - [https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-put-template.html](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-put-template.html) 
