### PR TITLE
Long session alert rule fix

### DIFF
--- a/kibana/transforms/long-session.curl
+++ b/kibana/transforms/long-session.curl
@@ -28,7 +28,7 @@ curl --location --request PUT 'https://localhost:9200/_transform/wso2-iam-alert-
                     },
                     {
                         "match": {
-                            "event.payloadData.rememberMeFlag": true
+                            "event.payloadData.rememberMeFlag": false
                         }
                     }
                 ]


### PR DESCRIPTION
Long session alert rule query changed to match **"event.payloadData.rememberMeFlag": false**

Fixes https://github.com/wso2/product-is/issues/13966