### PR TITLE
Change registry path of Filebeat

### DIFF
--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -10,7 +10,7 @@ filebeat.inputs:
   include_lines: ['Event:']
   paths:
    - <IS_HOME>/repository/logs/wso2carbon*.log
-filebeat.registry.path: /var/lib/filebeat/registry
+filebeat.registry.path: ./registry
 output.logstash:
   hosts: ["localhost:5044"]
 


### PR DESCRIPTION
Filebeat needs registry path to be accessible to keep track of logs. [Current path is relative](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#_registry_path) to `Data` path. Permissions should follow the [mentioned guidelines](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#_registry_file_permissions) in Filebeat.

Fixes https://github.com/wso2/product-is/issues/13940